### PR TITLE
Support for non-ascii characters in identifiers

### DIFF
--- a/src/examples/java/org/parboiled/examples/java/AbstractJavaCharacterMatcher.java
+++ b/src/examples/java/org/parboiled/examples/java/AbstractJavaCharacterMatcher.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2009-2010 Mathias Doenitz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.parboiled.examples.java;
+
+import org.jetbrains.annotations.NotNull;
+import org.parboiled.MatcherContext;
+import org.parboiled.matchers.CustomMatcher;
+
+public abstract class AbstractJavaCharacterMatcher extends CustomMatcher {
+    @Override
+    public final boolean isSingleCharMatcher() {
+        return true;
+    }
+
+    @Override
+    public final boolean canMatchEmpty() {
+        return false;
+    }
+
+    @Override
+    public boolean isStarterChar(char c) {
+        return acceptChar(c);
+    }
+
+    @Override
+    public final char getStarterChar() {
+        return 'a';
+    }
+
+    @Override
+    public final <V> boolean match(@NotNull MatcherContext<V> context) {
+        if (!acceptChar(context.getCurrentChar())) {
+            return false;
+        }
+        context.advanceIndex(1);
+        context.createNode();
+        return true;
+    }
+
+    protected abstract boolean acceptChar(char c);
+}

--- a/src/examples/java/org/parboiled/examples/java/JavaLetterMatcher.java
+++ b/src/examples/java/org/parboiled/examples/java/JavaLetterMatcher.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2010 Mathias Doenitz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.parboiled.examples.java;
+
+public class JavaLetterMatcher extends AbstractJavaCharacterMatcher {
+    @Override
+    protected boolean acceptChar(char c) {
+        return Character.isJavaIdentifierStart(c);
+    }
+}

--- a/src/examples/java/org/parboiled/examples/java/JavaLetterOrDigitMatcher.java
+++ b/src/examples/java/org/parboiled/examples/java/JavaLetterOrDigitMatcher.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2009-2010 Mathias Doenitz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.parboiled.examples.java;
+
+public class JavaLetterOrDigitMatcher extends AbstractJavaCharacterMatcher {
+    @Override
+    protected boolean acceptChar(char c) {
+        return Character.isJavaIdentifierPart(c);
+    }
+}

--- a/src/examples/java/org/parboiled/examples/java/JavaParser.java
+++ b/src/examples/java/org/parboiled/examples/java/JavaParser.java
@@ -866,18 +866,16 @@ public class JavaParser extends BaseParser<Object> {
         return Sequence(TestNot(Keyword()), Letter(), ZeroOrMore(LetterOrDigit()), Spacing());
     }
 
-    // The following are traditional definitions of letters and digits.
     // JLS defines letters and digits as Unicode characters recognized
-    // as such by special Java procedures, which is difficult
-    // to express in terms of Parsing Expressions.
+    // as such by special Java procedures.
 
     Rule Letter() {
-        return FirstOf(CharRange('a', 'z'), CharRange('A', 'Z'), '_', '$');
+        return FirstOf(UnicodeEscape(), new JavaLetterMatcher());
     }
 
     @MemoMismatches
     Rule LetterOrDigit() {
-        return FirstOf(CharRange('a', 'z'), CharRange('A', 'Z'), CharRange('0', '9'), '_', '$');
+        return FirstOf(UnicodeEscape(), new JavaLetterOrDigitMatcher());
     }
 
     //-------------------------------------------------------------------------
@@ -1039,19 +1037,20 @@ public class JavaParser extends BaseParser<Object> {
     }
 
     Rule Escape() {
-        return Sequence('\\', FirstOf(AnyOf("btnfr\"\'\\"), OctalEscape(), UnicodeEscape()));
+        return FirstOf(Sequence('\\', AnyOf("btnfr\"\'\\")), OctalEscape(), UnicodeEscape());
     }
 
     Rule OctalEscape() {
-        return FirstOf(
-                Sequence(CharRange('0', '3'), CharRange('0', '7'), CharRange('0', '7')),
-                Sequence(CharRange('0', '7'), CharRange('0', '7')),
-                CharRange('0', '7')
-        );
+        return Sequence(
+                '\\',
+                FirstOf(Sequence(CharRange('0', '3'), CharRange('0', '7'),
+                        CharRange('0', '7')),
+                        Sequence(CharRange('0', '7'), CharRange('0', '7')),
+                        CharRange('0', '7')));
     }
 
     Rule UnicodeEscape() {
-        return Sequence(OneOrMore('u'), HexDigit(), HexDigit(), HexDigit(), HexDigit());
+        return Sequence('\\', OneOrMore('u'), HexDigit(), HexDigit(), HexDigit(), HexDigit());
     }
 
     //-------------------------------------------------------------------------

--- a/src/test/java/org/parboiled/examples/JavaTest.java
+++ b/src/test/java/org/parboiled/examples/JavaTest.java
@@ -34,7 +34,11 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 public class JavaTest {
-
+    @SuppressWarnings("unused")
+    private char \u0041_identifierWithNonAsciiCharacters_åäöÅÄÖ_\u0030_$ = '\u0061';
+    @SuppressWarnings("unused")
+    private char[] octalEscapes = new char[] {'\1', '\12', '\123'};
+	
     @Test
     public void simpleJavaTest() {
         String testSource = FileUtils.readAllText("src/test/java/org/parboiled/examples/JavaTest.java");


### PR DESCRIPTION
Hello,

I implemented support for non-ascii characters in identifiers (as allowed in JLS) in org.parboiled.examples.java.JavaParser. In org.parboiled.examples.JavaTest I have added two new fields to test this functionality: JavaTest now cannot be parsed by the current version of JavaParser without my changes. It would be nice if you merged these changes to parboiled, since it would be good to have a fully functional Java parser, capable of parsing any Java which passes javac.

I tried to follow your coding style as closely as possible. Apache License is included in all new source files.

Best regards,
Ville Peurala
