### PR TITLE
added method for clearing class cache in AsmUtil

### DIFF
--- a/parboiled-java/src/main/java/org/parboiled/transform/AsmUtils.java
+++ b/parboiled-java/src/main/java/org/parboiled/transform/AsmUtils.java
@@ -88,6 +88,10 @@ class AsmUtils {
         return clazz;
     }
 
+    public static synchronized void clearClassCache() {
+        classForDesc.clear();
+    }
+
     public static Class<?> getClassForType(Type type) {
         checkArgNotNull(type, "type");
         switch (type.getSort()) {


### PR DESCRIPTION
AsmUtil holds references to loaded parser classes indefinitely - this can causes a 'memory leak' in long running applications when generating parser classes on-the-fly as the cache prevents them from being GC'd when we're finished with them. 

This additional method enables a workaround.