### PR TITLE
be compatible with Scala 2.12 community build

### DIFF
--- a/parboiled-scala/src/main/scala/org/parboiled/scala/testing/ParboiledTest.scala
+++ b/parboiled-scala/src/main/scala/org/parboiled/scala/testing/ParboiledTest.scala
@@ -27,7 +27,8 @@ import org.parboiled.Node
  * It can be mixed into any test class that defines a fail(string) method (e.g. all the scalatest Suites).
  */
 trait ParboiledTest {
-  this: {def fail(msg: String): Nothing} =>
+
+  def fail(message: String)(implicit pos: org.scalactic.source.Position): Nothing
 
   /**
    * The type of the root value object created by the parser.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -42,6 +42,8 @@ object Build extends Build {
 
     libraryDependencies   ++= test(testNG, scalatest(scalaVersion.value)),
 
+    libraryDependencies   += "org.scalactic" %% "scalactic" % "3.0.0",
+
     // scaladoc settings
     (scalacOptions in doc) <++= (name, version).map { (n, v) => Seq("-doc-title", n, "-doc-version", v) },
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,7 @@ object Dependencies {
       case "2.9.3" => "1.9.2"
       case "2.10.4" => "2.2.4"
       case "2.11.5" => "2.2.4"
+      case x if x.startsWith("2.12.") => "3.0.0"
     }
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.12


### PR DESCRIPTION
NOTE: not to be merged as-is.

to keep including parboiled in the community build, we needed some
change like this because the community build now has ScalaTest 3.0.x,
not 2.x anymore.

in 3.0, scalactic is a separate dependency, and `fail`'s signature
changed.

but I see you are using a variety of different ScalaTest versions,
depending on Scala version.  perhaps you can move to ScalaTest 3.0
across the board...?

(if you don't want to mess with it, we could keep using my fork
in the community build...)