### PR TITLE
add ASM API version to RuleMethodInterpreter and allow usage with ASM6

### DIFF
--- a/parboiled-java/src/main/java/org/parboiled/transform/RuleMethodInterpreter.java
+++ b/parboiled-java/src/main/java/org/parboiled/transform/RuleMethodInterpreter.java
@@ -40,6 +40,7 @@ class RuleMethodInterpreter extends BasicInterpreter {
     private final List<Edge> additionalEdges = new ArrayList<Edge>();
 
     public RuleMethodInterpreter(RuleMethod method) {
+        super(ASM5);
         this.method = method;
     }
 


### PR DESCRIPTION
in ASM6 the default constructor of BasicInterpreter throws IllegalStateException if (this.getClass() != BasicInterpreter.class) to avoid this the subclass has to use the protected constructor which accepts the API version