### PR TITLE
drop support for Java 1.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ val basicSettings = Seq(
 
   javacOptions          ++= Seq(
     "-deprecation",
-    "-target", "1.5",
-    "-source", "1.5",
+    "-target", "1.6",
+    "-source", "1.6",
     "-encoding", "utf8",
     "-Xlint:unchecked"
   ),


### PR DESCRIPTION
-source 1.5 and -target 1.5 are no longer supported on Java 9,
so this change is needed in order to build on Java 9

building on Java 9 isn't a must-have, but it's a nice-to-have
for the Scala 2.12 community build, which we run on both Java 8
and Java 9