### PR TITLE
Use class loader of parser base class in ClassWriter.

### DIFF
--- a/parboiled-java/src/main/java/org/parboiled/transform/ParserTransformer.java
+++ b/parboiled-java/src/main/java/org/parboiled/transform/ParserTransformer.java
@@ -93,8 +93,13 @@ public class ParserTransformer {
         );
     }
 
-    private static void defineExtendedParserClass(ParserClassNode classNode) {
-        ClassWriter classWriter = new ClassWriter(ASMSettings.FRAMES);
+    private static void defineExtendedParserClass(final ParserClassNode classNode) {
+        ClassWriter classWriter = new ClassWriter(ASMSettings.FRAMES) {
+            @Override
+            protected ClassLoader getClassLoader() {
+                return classNode.getParentClass().getClassLoader();
+            }
+        };
         classNode.accept(classWriter);
         classNode.setClassCode(classWriter.toByteArray());
         classNode.setExtendedClass(loadClass(


### PR DESCRIPTION
Ensures that ClassWriter.getCommonSuperClass uses
the class loader of the parser class and not
the class loader of the ASM classes (which is the default).
This fixes class loading problems in OSGi environments.