### PR TITLE
Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,12 @@ jobs:
         include:
           - java: 8
           - java: 11
+          - java: 17
     steps:
     - uses: actions/checkout@v2.4.0
-    - uses: olafurpg/setup-scala@v13
+    - uses: actions/setup-java@v2
       with:
-        java-version: "adopt@1.${{ matrix.java }}"
+        java-version: ${{ matrix.java }}
+        distribution: temurin
     - uses: coursier/cache-action@v6
     - run: sbt -v "+ test"


### PR DESCRIPTION
Java 17 support via providing required module patching in jar MANIFEST.

I've localized the problem to a single module patch that is required to make parboiled work on Java 17 - parboiled-java needs reflective access to java.base/java.lang package.

We can provide this access via explicit module patching.

Consumers of parboiled library won't have to do it, since parboiled will come with manifest entry instructing JVM to do it implicitly.