### PR TITLE
Use MethodHandles.Lookup to define new classes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - java: 8
           - java: 11
           - java: 17
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ val basicSettings = Seq(
 
   javacOptions          ++= Seq(
     "-deprecation",
-    "-target", "1.7",
-    "-source", "1.7",
+    "-target", "11",
+    "-source", "11",
     "-encoding", "utf8",
     "-Xlint:unchecked"
   ),

--- a/parboiled-java/src/main/java/org/parboiled/transform/GroupClassGenerator.java
+++ b/parboiled-java/src/main/java/org/parboiled/transform/GroupClassGenerator.java
@@ -70,7 +70,8 @@ abstract class GroupClassGenerator implements RuleMethodProcessor {
     private void createGroupClassType(InstructionGroup group) {
         String s = classNode.name;
         int lastSlash = classNode.name.lastIndexOf('/');
-        String groupClassInternalName = (lastSlash >= 0 ? s.substring(0, lastSlash) + '/': "") + group.getName();
+        // do not prepend a slash if class is in the default package (lastSlash == -1)
+        String groupClassInternalName = (lastSlash >= 0 ? s.substring(0, lastSlash) + '/' : "") + group.getName();
         group.setGroupClassType(Type.getObjectType(groupClassInternalName));
     }
 

--- a/parboiled-java/src/main/java/org/parboiled/transform/GroupClassGenerator.java
+++ b/parboiled-java/src/main/java/org/parboiled/transform/GroupClassGenerator.java
@@ -23,8 +23,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.*;
 
 import static org.objectweb.asm.Opcodes.*;
-import static org.parboiled.transform.AsmUtils.findLoadedClass;
-import static org.parboiled.transform.AsmUtils.loadClass;
+import static org.parboiled.transform.AsmUtils.defineClass;
 
 abstract class GroupClassGenerator implements RuleMethodProcessor {
 
@@ -54,16 +53,15 @@ abstract class GroupClassGenerator implements RuleMethodProcessor {
     private void loadGroupClass(InstructionGroup group) {
         createGroupClassType(group);
         String className = group.getGroupClassType().getClassName();
-        ClassLoader classLoader = classNode.getParentClass().getClassLoader();
 
         Class<?> groupClass;
         synchronized (lock) {
-            groupClass = findLoadedClass(className, classLoader);
+            groupClass = AsmUtils.loadClass(className, classNode.getParentClass());
             if (groupClass == null || forceCodeBuilding) {
                 byte[] groupClassCode = generateGroupClassCode(group);
                 group.setGroupClassCode(groupClassCode);
                 if (groupClass == null) {
-                    loadClass(className, groupClassCode, classLoader);
+                    AsmUtils.defineClass(className, groupClassCode, classNode.getParentClass());
                 }
             }
         }
@@ -72,7 +70,7 @@ abstract class GroupClassGenerator implements RuleMethodProcessor {
     private void createGroupClassType(InstructionGroup group) {
         String s = classNode.name;
         int lastSlash = classNode.name.lastIndexOf('/');
-        String groupClassInternalName = (lastSlash >= 0 ? s.substring(0, lastSlash) : s)+ '/' + group.getName();
+        String groupClassInternalName = (lastSlash >= 0 ? s.substring(0, lastSlash) + '/': "") + group.getName();
         group.setGroupClassType(Type.getObjectType(groupClassInternalName));
     }
 

--- a/parboiled-java/src/main/java/org/parboiled/transform/InstructionGraphCreator.java
+++ b/parboiled-java/src/main/java/org/parboiled/transform/InstructionGraphCreator.java
@@ -23,6 +23,8 @@
 package org.parboiled.transform;
 
 import static org.parboiled.common.Preconditions.*;
+
+import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.analysis.Analyzer;
 
 /**
@@ -51,7 +53,7 @@ class InstructionGraphCreator implements RuleMethodProcessor {
                 interpreter.newControlFlowEdge(insn, successor);
                 return true;
             }
-        }.analyze(classNode.name, method);
+        }.analyze(Type.getInternalName(classNode.getParentClass()), method);
 
         interpreter.finish();
     }

--- a/parboiled-java/src/main/java/org/parboiled/transform/LookupFactory.java
+++ b/parboiled-java/src/main/java/org/parboiled/transform/LookupFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 parboiled contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.parboiled.transform;
+
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.WeakHashMap;
+
+/**
+ * Helper that defines classes using {@code MethodHandles.Lookup#defineClass}.
+ */
+final class LookupFactory {
+
+	private WeakHashMap<Class<?>, Lookup> lookups = new WeakHashMap<>();
+	private Lookup trustedLookup;
+
+	LookupFactory() {
+		loadTrustedLookup();
+	}
+
+	private void loadTrustedLookup() {
+		try {
+			Class<?> unsafeType = Class.forName("sun.misc.Unsafe");
+			Field theUnsafeField = unsafeType.getDeclaredField("theUnsafe");
+			theUnsafeField.setAccessible(true);
+			Object unsafeInstance = theUnsafeField.get(null);
+			Field trustedLookupField = Lookup.class.getDeclaredField("IMPL_LOOKUP");
+			Method baseMethod = unsafeType.getMethod("staticFieldBase", Field.class);
+			Object trustedLookupBase = baseMethod.invoke(unsafeInstance, trustedLookupField);
+			Method offsetMethod = unsafeType.getMethod("staticFieldOffset", Field.class);
+			Object trustedLookupOffset = offsetMethod.invoke(unsafeInstance, trustedLookupField);
+			Method getObjectMethod = unsafeType.getMethod("getObject", Object.class, long.class);
+			this.trustedLookup =
+					(Lookup) getObjectMethod.invoke(unsafeInstance, trustedLookupBase, trustedLookupOffset);
+		} catch (Exception e) {
+			// Unsafe and trusted lookup is not available
+		}
+	}
+
+	Lookup lookupFor(Class<?> hostClass) {
+		Lookup lookup = lookups.get(hostClass);
+		if (lookup == null) {
+			try {
+				// try to find a lookup() method first
+				Method lookupMethod = hostClass.getMethod("lookup");
+				lookup = (Lookup) lookupMethod.invoke(null);
+			} catch (Exception e) {
+				// failed to use lookup() method
+			}
+
+			if (lookup == null && trustedLookup != null) {
+				// use trusted lookup instance if available
+				lookup = trustedLookup.in(hostClass);
+			}
+
+			if (lookup != null) {
+				lookups.put(hostClass, lookup);
+			}
+		}
+		return lookup;
+	}
+}

--- a/parboiled-java/src/main/java/org/parboiled/transform/LookupFactory.java
+++ b/parboiled-java/src/main/java/org/parboiled/transform/LookupFactory.java
@@ -22,7 +22,8 @@ import java.lang.reflect.Method;
 import java.util.WeakHashMap;
 
 /**
- * Helper that defines classes using {@code MethodHandles.Lookup#defineClass}.
+ * Helper that can be used to create {@link Lookup} instances for
+ * specific classes.
  */
 final class LookupFactory {
 
@@ -33,6 +34,14 @@ final class LookupFactory {
 		loadTrustedLookup();
 	}
 
+	/**
+	 * Tries to load a trusted {@link Lookup} instance.
+	 *
+	 * <p>
+	 * Adapted from <a href="https://github.com/google/guice/blob/cf759d44c78e8490e3d54df6a27918e0811bbdf9/core/src/com/google/inject/internal/aop/HiddenClassDefiner.java#L40">HiddenClassDefiner</a>
+	 * of Google Guice.
+	 * </p>
+	 */
 	private void loadTrustedLookup() {
 		try {
 			Class<?> unsafeType = Class.forName("sun.misc.Unsafe");
@@ -52,6 +61,25 @@ final class LookupFactory {
 		}
 	}
 
+	/**
+	 * Determines a {@link Lookup} instance for the given hostClass.
+	 * <p>
+	 * The method first tries to use a static method of the hostClass with the
+	 * following signature:
+	 * </p>
+	 * <p>
+	 * <code>
+	 *     public static {@link Lookup} lookup();
+	 * </code>
+	 * </p>
+	 * <p>
+	 * If this fails then it tries to use a trusted lookup
+	 * instance created via sun.misc.Unsafe.
+	 * </p>
+	 *
+	 * @param hostClass The target class of the lookup instance
+	 * @return a lookup instance or <code>null</code> if not found
+	 */
 	Lookup lookupFor(Class<?> hostClass) {
 		Lookup lookup = lookups.get(hostClass);
 		if (lookup == null) {

--- a/parboiled-java/src/main/java/org/parboiled/transform/ParserTransformer.java
+++ b/parboiled-java/src/main/java/org/parboiled/transform/ParserTransformer.java
@@ -32,8 +32,8 @@ public class ParserTransformer {
     public static synchronized <T> Class<? extends T> transformParser(Class<T> parserClass) throws Exception {
         checkArgNotNull(parserClass, "parserClass");
         // first check whether we did not already create and load the extension of the given parser class
-        Class<?> extendedClass = findLoadedClass(
-                getExtendedParserClassName(parserClass.getName()), parserClass.getClassLoader()
+        Class<?> extendedClass = AsmUtils.loadClass(
+                getExtendedParserClassName(parserClass.getName()), parserClass
         );
         return (Class<? extends T>)
                 (extendedClass != null ? extendedClass : extendParserClass(parserClass).getExtendedClass());
@@ -102,10 +102,10 @@ public class ParserTransformer {
         };
         classNode.accept(classWriter);
         classNode.setClassCode(classWriter.toByteArray());
-        classNode.setExtendedClass(loadClass(
+        classNode.setExtendedClass(defineClass(
                 classNode.name.replace('/', '.'),
                 classNode.getClassCode(),
-                classNode.getParentClass().getClassLoader()
+                classNode.getParentClass()
         ));
     }
 

--- a/parboiled-java/src/test/java/org/parboiled/ActionTest.java
+++ b/parboiled-java/src/test/java/org/parboiled/ActionTest.java
@@ -135,13 +135,13 @@ public class ActionTest extends TestNgParboiledTest<Integer> {
 
         assertEquals(stats.printActionClassInstances(), "" +
                 "Action classes and their instances for rule 'A':\n" +
-                "    Action$0QAUd2XJhkFkwVyB : D_Action2\n" +
-                "    Action$BYXjsBCgkaYmhXqh : D_Action3\n" +
-                "    Action$M1hejMpBJ5SjCHvC : B_Action1\n" +
-                "    Action$Qy8BzTl3RpzAzrXV : A_Action1\n" +
-                "    Action$Syt5vvsOCzKOZ8Az : D_Action1\n" +
-                "    Action$esdKf3Sj9cYL9I1s : B_Action2, C_Action1\n" +
-                "    Action$xipkqpZJpsrvOANU : A_Action2\n" +
+                "    Action$KT5vcoYNBwlSxCxf : B_Action1\n" +
+                "    Action$PAqU0LvxzUVoURCx : A_Action1\n" +
+                "    Action$fKILGTA7SHvK2Wv0 : A_Action2\n" +
+                "    Action$m85l2h2jwKmRq8Y3 : B_Action2, C_Action1\n" +
+                "    Action$n449VU3wlEEz4TDj : D_Action3\n" +
+                "    Action$phKm3I8AzhaefYYv : D_Action1\n" +
+                "    Action$uNJUVN3EfXLXlH8Y : D_Action2\n" +
                 "    and 1 anonymous instance(s)\n");
     }
 

--- a/parboiled-java/src/test/java/org/parboiled/PrevCallsTest.java
+++ b/parboiled-java/src/test/java/org/parboiled/PrevCallsTest.java
@@ -22,6 +22,8 @@ import org.parboiled.common.Reference;
 import org.parboiled.test.TestNgParboiledTest;
 import org.testng.annotations.Test;
 
+import java.lang.invoke.MethodHandles;
+
 public class PrevCallsTest extends TestNgParboiledTest<Integer> {
 
     @BuildParseTree
@@ -62,7 +64,6 @@ public class PrevCallsTest extends TestNgParboiledTest<Integer> {
                     push(Integer.parseInt(match()))
             );
         }
-
     }
 
     @Test

--- a/parboiled-java/src/test/java/org/parboiled/transform/ActionClassGeneratorTest.java
+++ b/parboiled-java/src/test/java/org/parboiled/transform/ActionClassGeneratorTest.java
@@ -126,11 +126,11 @@ public class ActionClassGeneratorTest extends TransformationTest {
         assertEquals(getClassDump(group.getGroupClassCode()), "" +
                 "// class version 51.0 (51)\n" +
                 "// access flags 0x1011\n" +
-                "public final synthetic class org/parboiled/transform/Action$OrG2zjbz0MYoT8sO extends org/parboiled/transform/BaseAction {\n" +
+                "public final synthetic class org/parboiled/transform/Action$xPqljUb88dWGGhyd extends org/parboiled/transform/BaseAction {\n" +
                 "\n" +
                 "\n" +
                 "  // access flags 0x1001\n" +
-                "  public synthetic Lorg/parboiled/transform/TestParser$$parboiled; field$0\n" +
+                "  public synthetic Lorg/parboiled/transform/TestParser; field$0\n" +
                 "\n" +
                 "  // access flags 0x1001\n" +
                 "  public synthetic I field$1\n" +
@@ -156,21 +156,21 @@ public class ActionClassGeneratorTest extends TransformationTest {
                 "  // access flags 0x1\n" +
                 "  public run(Lorg/parboiled/Context;)Z\n" +
                 "    ALOAD 0\n" +
-                "    GETFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$0 : Lorg/parboiled/transform/TestParser$$parboiled;\n" +
+                "    GETFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$0 : Lorg/parboiled/transform/TestParser;\n" +
                 "    GETFIELD org/parboiled/transform/TestParser.integer : I\n" +
                 "    ALOAD 0\n" +
-                "    GETFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$1 : I\n" +
+                "    GETFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$1 : I\n" +
                 "    IADD\n" +
                 "    ALOAD 0\n" +
-                "    GETFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$2 : Lorg/parboiled/support/Var;\n" +
+                "    GETFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$2 : Lorg/parboiled/support/Var;\n" +
                 "    INVOKEVIRTUAL org/parboiled/support/Var.get ()Ljava/lang/Object;\n" +
                 "    CHECKCAST java/lang/String\n" +
                 "    INVOKEVIRTUAL java/lang/String.length ()I\n" +
                 "    ALOAD 0\n" +
-                "    GETFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$3 : I\n" +
+                "    GETFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$3 : I\n" +
                 "    ISUB\n" +
                 "    ALOAD 0\n" +
-                "    GETFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$4 : I\n" +
+                "    GETFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$4 : I\n" +
                 "    ISUB\n" +
                 "    IF_ICMPGE L0\n" +
                 "    ICONST_1\n" +

--- a/parboiled-java/src/test/java/org/parboiled/transform/InstructionGroupPreparerTest.java
+++ b/parboiled-java/src/test/java/org/parboiled/transform/InstructionGroupPreparerTest.java
@@ -56,9 +56,9 @@ public class InstructionGroupPreparerTest extends TransformationTest {
         assertEquals(group.getFields().get(2).desc, "I");
 
         group = method.getGroups().get(2);
-        assertEquals(group.getName(), "Action$OrG2zjbz0MYoT8sO");
+        assertEquals(group.getName(), "Action$xPqljUb88dWGGhyd");
         assertEquals(group.getFields().size(), 5);
-        assertEquals(group.getFields().get(0).desc, "Lorg/parboiled/transform/TestParser$$parboiled;");
+        assertEquals(group.getFields().get(0).desc, "Lorg/parboiled/transform/TestParser;");
         assertEquals(group.getFields().get(1).desc, "I");
         assertEquals(group.getFields().get(2).desc, "Lorg/parboiled/support/Var;");
         assertEquals(group.getFields().get(3).desc, "I");

--- a/parboiled-java/src/test/java/org/parboiled/transform/LookupMethodTest.java
+++ b/parboiled-java/src/test/java/org/parboiled/transform/LookupMethodTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 parboiled contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.parboiled.transform;
+
+import org.parboiled.BaseParser;
+import org.parboiled.Parboiled;
+import org.parboiled.Rule;
+import org.parboiled.test.TestNgParboiledTest;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandles;
+
+public class LookupMethodTest extends TestNgParboiledTest<Integer> {
+    static boolean lookupMethodInvoked = false;
+
+    public static class Parser extends BaseParser<Integer> {
+
+        public Rule A() {
+            return Sequence('a', push(42));
+        }
+
+        public static MethodHandles.Lookup lookup() {
+            lookupMethodInvoked = true;
+            return MethodHandles.lookup();
+        }
+    }
+
+    @Test
+    public void testLookupMethodUsed() {
+        Parser parser = Parboiled.createParser(Parser.class);
+        Assert.assertTrue(lookupMethodInvoked, "The lookup() method must be used if available.");
+    }
+}

--- a/parboiled-java/src/test/java/org/parboiled/transform/ParserHierarchyTest.java
+++ b/parboiled-java/src/test/java/org/parboiled/transform/ParserHierarchyTest.java
@@ -124,13 +124,13 @@ public class ParserHierarchyTest {
                 " 0     ALOAD 0\n" +
                 " 1     BIPUSH 66\n" +
                 " 2     INVOKESTATIC java/lang/Character.valueOf (C)Ljava/lang/Character;\n" +
-                " 3     NEW org/parboiled/transform/Action$Px2Jp4FIYS9AjKV7\n" +
+                " 3     NEW org/parboiled/transform/Action$02sFO02Q9LhJ2mmp\n" +
                 " 4     DUP\n" +
                 " 5     LDC \"$B_Action1\"\n" +
-                " 6     INVOKESPECIAL org/parboiled/transform/Action$Px2Jp4FIYS9AjKV7.<init> (Ljava/lang/String;)V\n" +
+                " 6     INVOKESPECIAL org/parboiled/transform/Action$02sFO02Q9LhJ2mmp.<init> (Ljava/lang/String;)V\n" +
                 " 7     DUP\n" +
                 " 8     ALOAD 0\n" +
-                " 9     PUTFIELD org/parboiled/transform/Action$Px2Jp4FIYS9AjKV7.field$0 : Lorg/parboiled/transform/ParserHierarchyTest$Parser3$$parboiled;\n" +
+                " 9     PUTFIELD org/parboiled/transform/Action$02sFO02Q9LhJ2mmp.field$0 : Lorg/parboiled/transform/ParserHierarchyTest$Parser3;\n" +
                 "10     ICONST_0\n" +
                 "11     ANEWARRAY java/lang/Object\n" +
                 "12     INVOKEVIRTUAL org/parboiled/transform/ParserHierarchyTest$Parser1.Sequence (Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Lorg/parboiled/Rule;\n" +
@@ -160,13 +160,13 @@ public class ParserHierarchyTest {
                 "20     ANEWARRAY java/lang/Object\n" +
                 "21     DUP\n" +
                 "22     ICONST_0\n" +
-                "23     NEW org/parboiled/transform/Action$k4qTyX8Zgn8Lm8a0\n" +
+                "23     NEW org/parboiled/transform/Action$UbnKC3brDnPwNKXv\n" +
                 "24     DUP\n" +
                 "25     LDC \"B_Action1\"\n" +
-                "26     INVOKESPECIAL org/parboiled/transform/Action$k4qTyX8Zgn8Lm8a0.<init> (Ljava/lang/String;)V\n" +
+                "26     INVOKESPECIAL org/parboiled/transform/Action$UbnKC3brDnPwNKXv.<init> (Ljava/lang/String;)V\n" +
                 "27     DUP\n" +
                 "28     ALOAD 0\n" +
-                "29     PUTFIELD org/parboiled/transform/Action$k4qTyX8Zgn8Lm8a0.field$0 : Lorg/parboiled/transform/ParserHierarchyTest$Parser3$$parboiled;\n" +
+                "29     PUTFIELD org/parboiled/transform/Action$UbnKC3brDnPwNKXv.field$0 : Lorg/parboiled/transform/ParserHierarchyTest$Parser3;\n" +
                 "30     AASTORE\n" +
                 "31     INVOKEVIRTUAL org/parboiled/transform/ParserHierarchyTest$Parser3.Sequence (Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Lorg/parboiled/Rule;\n" +
                 "32     DUP\n" +
@@ -187,13 +187,13 @@ public class ParserHierarchyTest {
                 " 0     ALOAD 0\n" +
                 " 1     ALOAD 0\n" +
                 " 2     INVOKESPECIAL org/parboiled/transform/ParserHierarchyTest$Parser1.C ()Lorg/parboiled/Rule;\n" +
-                " 3     NEW org/parboiled/transform/Action$zJfzDznnLMaJTxvg\n" +
+                " 3     NEW org/parboiled/transform/Action$COjnrfuG0T4POBCt\n" +
                 " 4     DUP\n" +
                 " 5     LDC \"$C_Action1\"\n" +
-                " 6     INVOKESPECIAL org/parboiled/transform/Action$zJfzDznnLMaJTxvg.<init> (Ljava/lang/String;)V\n" +
+                " 6     INVOKESPECIAL org/parboiled/transform/Action$COjnrfuG0T4POBCt.<init> (Ljava/lang/String;)V\n" +
                 " 7     DUP\n" +
                 " 8     ALOAD 0\n" +
-                " 9     PUTFIELD org/parboiled/transform/Action$zJfzDznnLMaJTxvg.field$0 : Lorg/parboiled/transform/ParserHierarchyTest$Parser3$$parboiled;\n" +
+                " 9     PUTFIELD org/parboiled/transform/Action$COjnrfuG0T4POBCt.field$0 : Lorg/parboiled/transform/ParserHierarchyTest$Parser3;\n" +
                 "10     ICONST_0\n" +
                 "11     ANEWARRAY java/lang/Object\n" +
                 "12     INVOKEVIRTUAL org/parboiled/transform/ParserHierarchyTest$Parser2.Sequence (Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Lorg/parboiled/Rule;\n" +

--- a/parboiled-java/src/test/java/org/parboiled/transform/RuleMethodRewriterTest.java
+++ b/parboiled-java/src/test/java/org/parboiled/transform/RuleMethodRewriterTest.java
@@ -59,13 +59,13 @@ public class RuleMethodRewriterTest extends TransformationTest {
                 " 6     ANEWARRAY java/lang/Object\n" +
                 " 7     DUP\n" +
                 " 8     ICONST_0\n" +
-                " 9     NEW org/parboiled/transform/Action$K54Cjo0vNpv0KPTK\n" +
+                " 9     NEW org/parboiled/transform/Action$9oFgHpRIhPPzfI17\n" +
                 "10     DUP\n" +
                 "11     LDC \"RuleWithIndirectImplicitAction_Action1\"\n" +
-                "12     INVOKESPECIAL org/parboiled/transform/Action$K54Cjo0vNpv0KPTK.<init> (Ljava/lang/String;)V\n" +
+                "12     INVOKESPECIAL org/parboiled/transform/Action$9oFgHpRIhPPzfI17.<init> (Ljava/lang/String;)V\n" +
                 "13     DUP\n" +
                 "14     ALOAD 0\n" +
-                "15     PUTFIELD org/parboiled/transform/Action$K54Cjo0vNpv0KPTK.field$0 : Lorg/parboiled/transform/TestParser$$parboiled;\n" +
+                "15     PUTFIELD org/parboiled/transform/Action$9oFgHpRIhPPzfI17.field$0 : Lorg/parboiled/transform/TestParser;\n" +
                 "16     AASTORE\n" +
                 "17     INVOKEVIRTUAL org/parboiled/transform/TestParser.Sequence (Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Lorg/parboiled/Rule;\n" +
                 "18     ARETURN\n");
@@ -118,25 +118,25 @@ public class RuleMethodRewriterTest extends TransformationTest {
                 "43     AASTORE\n" +
                 "44     DUP\n" +
                 "45     ICONST_1\n" +
-                "46     NEW org/parboiled/transform/Action$OrG2zjbz0MYoT8sO\n" +
+                "46     NEW org/parboiled/transform/Action$xPqljUb88dWGGhyd\n" +
                 "47     DUP\n" +
                 "48     LDC \"RuleWithComplexActionSetup_Action2\"\n" +
-                "49     INVOKESPECIAL org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.<init> (Ljava/lang/String;)V\n" +
+                "49     INVOKESPECIAL org/parboiled/transform/Action$xPqljUb88dWGGhyd.<init> (Ljava/lang/String;)V\n" +
                 "50     DUP\n" +
                 "51     ALOAD 0\n" +
-                "52     PUTFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$0 : Lorg/parboiled/transform/TestParser$$parboiled;\n" +
+                "52     PUTFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$0 : Lorg/parboiled/transform/TestParser;\n" +
                 "53     DUP\n" +
                 "54     ILOAD 1\n" +
-                "55     PUTFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$1 : I\n" +
+                "55     PUTFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$1 : I\n" +
                 "56     DUP\n" +
                 "57     ALOAD 4\n" +
-                "58     PUTFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$2 : Lorg/parboiled/support/Var;\n" +
+                "58     PUTFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$2 : Lorg/parboiled/support/Var;\n" +
                 "59     DUP\n" +
                 "60     ILOAD 2\n" +
-                "61     PUTFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$3 : I\n" +
+                "61     PUTFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$3 : I\n" +
                 "62     DUP\n" +
                 "63     ILOAD 3\n" +
-                "64     PUTFIELD org/parboiled/transform/Action$OrG2zjbz0MYoT8sO.field$4 : I\n" +
+                "64     PUTFIELD org/parboiled/transform/Action$xPqljUb88dWGGhyd.field$4 : I\n" +
                 "65     AASTORE\n" +
                 "66     INVOKEVIRTUAL org/parboiled/transform/TestParser.Sequence (Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;)Lorg/parboiled/Rule;\n" +
                 "67     NEW org/parboiled/matchers/VarFramingMatcher\n" +

--- a/parboiled-java/src/test/java/org/parboiled/transform/VarInitClassGeneratorTest.java
+++ b/parboiled-java/src/test/java/org/parboiled/transform/VarInitClassGeneratorTest.java
@@ -120,14 +120,14 @@ public class VarInitClassGeneratorTest extends TransformationTest {
         assertEquals(getClassDump(group.getGroupClassCode()), "" +
                 "// class version 51.0 (51)\n" +
                 "// access flags 0x1011\n" +
-                "public final synthetic class org/parboiled/transform/Action$ha3NOiBr9DZ3I2Sh extends org/parboiled/transform/BaseAction {\n" +
+                "public final synthetic class org/parboiled/transform/Action$wahXW5a63chqvc1g extends org/parboiled/transform/BaseAction {\n" +
                 "\n" +
                 "\n" +
                 "  // access flags 0x1001\n" +
                 "  public synthetic Lorg/parboiled/support/Var; field$0\n" +
                 "\n" +
                 "  // access flags 0x1001\n" +
-                "  public synthetic Lorg/parboiled/transform/VarInitClassGeneratorTest$Parser$$parboiled; field$1\n" +
+                "  public synthetic Lorg/parboiled/transform/VarInitClassGeneratorTest$Parser; field$1\n" +
                 "\n" +
                 "  // access flags 0x1\n" +
                 "  public <init>(Ljava/lang/String;)V\n" +
@@ -141,11 +141,11 @@ public class VarInitClassGeneratorTest extends TransformationTest {
                 "  // access flags 0x1\n" +
                 "  public run(Lorg/parboiled/Context;)Z\n" +
                 "    ALOAD 0\n" +
-                "    GETFIELD org/parboiled/transform/Action$ha3NOiBr9DZ3I2Sh.field$0 : Lorg/parboiled/support/Var;\n" +
+                "    GETFIELD org/parboiled/transform/Action$wahXW5a63chqvc1g.field$0 : Lorg/parboiled/support/Var;\n" +
                 "    INVOKEVIRTUAL org/parboiled/support/Var.get ()Ljava/lang/Object;\n" +
                 "    CHECKCAST java/util/List\n" +
                 "    ALOAD 0\n" +
-                "    GETFIELD org/parboiled/transform/Action$ha3NOiBr9DZ3I2Sh.field$1 : Lorg/parboiled/transform/VarInitClassGeneratorTest$Parser$$parboiled;\n" +
+                "    GETFIELD org/parboiled/transform/Action$wahXW5a63chqvc1g.field$1 : Lorg/parboiled/transform/VarInitClassGeneratorTest$Parser;\n" +
                 "    DUP\n" +
                 "    ALOAD 1\n" +
                 "    INVOKEINTERFACE org/parboiled/ContextAware.setContext (Lorg/parboiled/Context;)V (itf)\n" +


### PR DESCRIPTION
- ensures compatibility with JDK 16 and newer
- gets lookup instance through static lookup() method on parser class
- uses sun.misc.Unsafe as another option to create trusted lookup
  (requires no changes to existing parser classes)

Fixes #175 